### PR TITLE
Remove global jobs handler

### DIFF
--- a/cmd/truewatcher/main.go
+++ b/cmd/truewatcher/main.go
@@ -39,8 +39,8 @@ func main() {
 	l = l.With("check_delay", cfg.CheckDelay.String())
 	l.Info("started")
 	if err := cl.MonitorApps(ctx); err != nil {
-		slog.With("error", err).Error("error monitoring the applications")
+		l.With("error", err).Error("error monitoring the applications")
 		os.Exit(1)
 	}
-	slog.Info("stopped")
+	l.Info("stopped")
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -104,13 +104,14 @@ func (c *Client) queryAndUpgrade(cl *sdk.Client) {
 			"app_name", app.Name,
 			"app_id", app.Id,
 			"upgrade_available", app.UpgradeAvailable,
+			"current_version", app.Version,
+			"latest_version", app.LatestVersion,
 		).Debug("app returned")
 		ok, err := c.upgradeApp(cl, app)
 		if err != nil {
 			slog.With(
 				"app_name", app.Name,
 				"app_id", app.Name,
-				"upgrade_available", app.UpgradeAvailable,
 				"current_version", app.Version,
 				"latest_version", app.LatestVersion,
 				"error", err,
@@ -120,7 +121,6 @@ func (c *Client) queryAndUpgrade(cl *sdk.Client) {
 			slog.With(
 				"app_name", app.Name,
 				"app_id", app.Name,
-				"upgrade_available", app.UpgradeAvailable,
 				"from_version", app.Version,
 				"to_version", app.LatestVersion,
 			).Info("app upgraded")

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -56,15 +56,7 @@ func (c *Client) MonitorApps(ctx context.Context) error {
 
 func (c *Client) connect() (*sdk.Client, func(), error) {
 	closer := func() {}
-	cl, err := sdk.NewClientWithCallback(c.URL, false, func(i int64, i2 int64, m map[string]interface{}) {
-		// NOTE: This is here for experimentation: It's under investigation on how to avoid querying and instead
-		// act based on the received notifications.
-		slog.With(
-			"i", i,
-			"i2", i2,
-			"m", m,
-		).Info("job received")
-	})
+	cl, err := sdk.NewClient(c.URL, false)
 	if err != nil {
 		return nil, closer, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,12 @@ func LoadConfig() Config {
 	rawCheckDelay := env.StringWithDefault("CHECK_DELAY", defaultCheckDelay.String())
 	delay, err := time.ParseDuration(rawCheckDelay)
 	if err != nil {
-		slog.With("given_value", rawCheckDelay).With("default", defaultCheckDelay.String()).With("error", err).Warn("failed to parse the given value for CHECK_DELAY. Fallback to default")
+		slog.
+			With(
+				"given_value", rawCheckDelay,
+				"default", defaultCheckDelay.String(),
+				"error", err,
+			).Warn("failed to parse the given value for CHECK_DELAY. Fallback to default")
 		delay = defaultCheckDelay
 	}
 	ret.CheckDelay = delay

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,3 @@ export TRUENAS_API_KEY="<the token you copied above>"
 In case you want to run this in your Portainer or Dockage instance, you can use the already existing and up to date [docker image](https://hub.docker.com/r/yottta/truewatcher).
 
 > The timezone of the container can be configured by using the TZ environment variable.
-
-## TODOs:
-* Actually plug into the events, still have to figure out what is the privilege necessary to receive events
-  for a least-privileged token.


### PR DESCRIPTION
Providing to the TrueNAS api-key with limited privileges, it never receives all the notifications of the jobs from the system.
Could find no specific permission for getting only the notifications or alerts that are meant for the user that the key is generated for. Until I am able to find more information about it, I will remove this from the code base to clean up logs and to remove from the noise.

